### PR TITLE
Update KMS CMK Access Policy

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -181,6 +181,14 @@ Resources:
                 - !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:root"
             Action: 'kms:*'
             Resource: '*'
+          - Effect: Allow
+            Principal:
+              Service:
+                -  cloudwatch.amazonaws.com
+            Action: 
+                - "kms:Decrypt"
+                - "kms:GenerateDataKey*"
+            Resource: '*'
 
 Outputs:
   WebApi:


### PR DESCRIPTION
CloudWatch Alarm action was failing with the error  "CloudWatch Alarms does not have authorization to access the SNS topic encryption key. it is because of the missing policy

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
